### PR TITLE
Fix typo in URL

### DIFF
--- a/pharo-by-example9/index.html
+++ b/pharo-by-example9/index.html
@@ -21,9 +21,9 @@
 <li>	<p>We have reorganized the beginning of the book to get shorter chapters.</p></li>
 <li> <p>We have introduced a new ’first contact’ chapter with a simple counter example. This lets the reader see the most important operations to define a class, its tests, and save its code.</p></li>
 <li> <p>We briefly cover the new system browser, Calypso, as well as the Pharo Launcher.</p></li>
-<li> <p>We have introduced a new chapter covering Iceberg and package management. A larger book on Pharo and git is available at <a href="http://books. pharo.org">http://books. pharo.org</a>.</p></li>
+<li> <p>We have introduced a new chapter covering Iceberg and package management. A larger book on Pharo and git is available at <a href="http://books.pharo.org">http://books.pharo.org</a>.</p></li>
 <li> <p>We added a new chapter on Traits.</p></li>
-<li> <p>We have simplified the SUnit chapter, since a companion book is now available at <a href="http://books. pharo.org">http://books. pharo.org</a></p></li>
+<li> <p>We have simplified the SUnit chapter, since a companion book is now available at <a href="http://books.pharo.org">http://books.pharo.org</a></p></li>
 <li> <p>We have revised parts of the book that were wrong in previous editions, such as the Morphic chapter; the current version is a considerable improvement over Pharo by Example 5.</p></li>
 </ul>
 				<!-- PDF and Printed version buttons -->


### PR DESCRIPTION
http://books.pharo.org instead of http://books. pharo.org